### PR TITLE
Updated domains.yml to include additional services

### DIFF
--- a/domains.yml
+++ b/domains.yml
@@ -12,19 +12,25 @@
  - bit.do
  - bit.ly:
      aliases: [ aaja.de, adct.me, archdai.ly, aspt.co, ccwc.me, crks.me,
-       bcool.bz, detne.ws, digs.by, drudge.tw, emu.sc, go72.de, got.cr, j.mp,
-       j-tv.me, hnnng.de, s.htc.com, kon.gg, livesi.de, perez.ly, rol.st,
-       scr.bi, theatln.tc, tgr.ph, trib.in, utsd.us, yhoo.it ]
+       bcool.bz, detne.ws, digs.by, drudge.tw, eluni.mx, emu.sc, go72.de, got.cr, j.mp,
+       j-tv.me, hnnng.de, s.htc.com, kon.gg, mile.io, livesi.de, perez.ly, record.mx, rol.st,
+       scr.bi, sopit.as, theatln.tc, tgr.ph, trib.in, utsd.us, yhoo.it ]
  #- budurl.me
  - chilp.it
  - clck.ru
  - cort.as
  - cutt.us
  - db.tt
+ - dlvr.it
+ - es.pn
  - fave.co
+ - fb.me
+ - feeds.feedburner.com
  - flic.kr
  - fur.ly
+ - gol.am
  - goo.gl
+ - ift.tt
  - is.gd
  - korta.nu
  - macte.ch
@@ -34,6 +40,7 @@
      select: '.general a'
  - notlong.com:
      match: '^(https?:)//[a-zA-Z0-9_-]+\.notlong\.com/'
+ - news.google.com
  - nsfw.in:
      select: '#long_url > a'
  - ow.ly:
@@ -41,6 +48,7 @@
  #- o-x.fr
  - qr.net
  - scrnch.me
+ - shar.es
  - shorl.com
  - smsh.me:
      select: '#redirectorTitle'
@@ -59,6 +67,7 @@
  - to.ly
  - tr.im
  - trim.li
+ - tvsa.mx
  - tw.gs:
     select: '#lurllink > a'
  - ur1.ca


### PR DESCRIPTION
Added the following additional providers domain:
 * gol.am
 * fb.me
 * es.pn
 * ift.tt
 * tvsa.mx
 * dlvr.it
 * feeds.feedburner.com
 * news.google.com 
 * shar.es

and the followin bit.ly alias (as branded domains):
* record.mx
* mile.io
* sopit.as
* eluni.mx

Note feeds.feedburner.com/news.google.com are not proper url-shortners but I have found them to be useful for the `expand()` function.