### PR TITLE
Added zpr.io to known domain names

### DIFF
--- a/domains.yml
+++ b/domains.yml
@@ -50,3 +50,4 @@
     link_selector: '.vut + .button'
 - wp.me
 - xurl.es
+- zpr.io


### PR DESCRIPTION
zpr.io works with a single redirect (301 result).
and can be safely added as supported domain without further changes.

Requirements for adding new site to defaults:

- It should be popular
- It should not be restricted to single domain (fb.me and others)
- Test for new site should exist (`npm run test-all`)

Anything else can be added via library API at user's side.
