### PR TITLE
Update import location.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 
 'use strict'
 
-const $ = require('cheerio/lib/slim').load('')
+const $ = require('cheerio/slim').load('')
 const read = require('fs').readFileSync
 const yaml = require('js-yaml')
 const path = require('path')

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lib/"
   ],
   "dependencies": {
-    "cheerio": "^1.0.0-rc.12",
+    "cheerio": "^1.0.0",
     "escape-string-regexp": "^4.0.0",
     "got": "^11.8.3",
     "is-google-domain": "^1.0.0",


### PR DESCRIPTION
This is the location as of Cheerio 1.0. See
https://github.com/cheeriojs/cheerio/blob/f865924a0907b842914166c3c61f69bdc5d0ed14/website/blog/2024-08-07-version-1.md

> Import paths were simplified. For example, use `cheerio/slim` instead of `cheerio/lib/slim`.
